### PR TITLE
style(child component output): If the output is not connected, set it…

### DIFF
--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -175,7 +175,7 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         var singleTopLevel             : Boolean = true,
                         var noAssertAtTimeZero         : Boolean = false,
                         var cutLongExpressions         : Boolean = true,
-                        var cleanOutput                : Boolean = false
+                        var emitFullComponentBindings  : Boolean = true
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)
   def generateVhdl   [T <: Component](gen: => T): SpinalReport[T] = Spinal(this.copy(mode = VHDL))(gen)

--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -174,7 +174,8 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         bitVectorWidthMax              : Int = 4096,
                         var singleTopLevel             : Boolean = true,
                         var noAssertAtTimeZero         : Boolean = false,
-                        var cutLongExpressions         : Boolean = true
+                        var cutLongExpressions         : Boolean = true,
+                        var cleanOutput                : Boolean = false
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)
   def generateVhdl   [T <: Component](gen: => T): SpinalReport[T] = Spinal(this.copy(mode = VHDL))(gen)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -165,7 +165,7 @@ class ComponentEmitterVerilog(
         val componentSignalName = (sub.getNameElseThrow + "_" + io.getNameElseThrow)
         val name = component.localNamingScope.allocateName(componentSignalName)
         val noUse = signalNoUse(io)
-        if (!io.isSuffix && (io.isVital || !noUse))
+        if (!io.isSuffix && ((io.isVital || !noUse) || !spinalConfig.cleanOutput))
           declarations ++= emitExpressionWrap(io, name)
         referencesOverrides(io) = name
       }
@@ -423,7 +423,7 @@ class ComponentEmitterVerilog(
             case spinal.core.inout => "~"
             case _ => SpinalError("Not founded IO type")
           }
-          if(data.isVital || !noUse)
+          if(data.isVital || !noUse || !spinalConfig.cleanOutput)
             Some((s"    .${portAlign} (", s"${wireAlign}", s")${comma} //${dirtag}\n"))
           else {
             referencesOverrides.remove(data)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -426,7 +426,7 @@ class ComponentEmitterVerilog(
             Some((s"    .${portAlign} (", s"${wireAlign}", s")${comma} //${dirtag}\n"))
           else {
             referencesOverrides.remove(data)
-            Some((s"    .${portAlign} (", s"", s")${comma} //${dirtag}\n"))
+            Some((s"    .${portAlign} (", s" ", s")${comma} //${dirtag}\n"))
           }
         }
       }

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -1736,25 +1736,25 @@ end
     }
   }
 
-  var outputSignalNoUse: Set[BaseType] = Set()
+  var outputSignalNoUse: mutable.LinkedHashSet[BaseType] = mutable.LinkedHashSet()
   if(!spinalConfig.emitFullComponentBindings) {
     component.children.foreach(sub =>
       sub.getAllIo
       .foreach(io => if(io.isOutput) {
-        outputSignalNoUse = outputSignalNoUse + io
+        outputSignalNoUse.add(io)
       }
     ))
-  }
-  component.dslBody.walkStatements {
-    case s: BaseType =>
-    case s => {
-      s.walkExpression {
-        case e: BaseType => {
-          if(outputSignalNoUse contains e) {
-            outputSignalNoUse = outputSignalNoUse - e
+    component.dslBody.walkStatements {
+      case s: BaseType =>
+      case s => {
+        s.walkExpression {
+          case e: BaseType => {
+            if(outputSignalNoUse contains e) {
+              outputSignalNoUse.remove(e)
+            }
           }
+          case _ =>
         }
-        case _ =>
       }
     }
   }


### PR DESCRIPTION
… to be an empty pair of parentheses

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
