### PR TITLE
feat(cutLongExpr): make cutLongExpression optional

### DIFF
--- a/core/src/main/scala/spinal/core/Spinal.scala
+++ b/core/src/main/scala/spinal/core/Spinal.scala
@@ -173,7 +173,8 @@ case class SpinalConfig(mode                           : SpinalMode = null,
                         var enumGlobalEnable           : Boolean = false,
                         bitVectorWidthMax              : Int = 4096,
                         var singleTopLevel             : Boolean = true,
-                        var noAssertAtTimeZero         : Boolean = false
+                        var noAssertAtTimeZero         : Boolean = false,
+                        var cutLongExpressions         : Boolean = true
 ){
   def generate       [T <: Component](gen: => T): SpinalReport[T] = Spinal(this)(gen)
   def generateVhdl   [T <: Component](gen: => T): SpinalReport[T] = Spinal(this.copy(mode = VHDL))(gen)

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVerilog.scala
@@ -171,7 +171,8 @@ class ComponentEmitterVerilog(
     ))
 
     //Wrap expression which need it
-    cutLongExpressions()
+    if(spinalConfig.cutLongExpressions)
+      cutLongExpressions()
     expressionToWrap --= wrappedExpressionToName.keysIterator
 
     component.dslBody.walkStatements { s =>

--- a/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
+++ b/core/src/main/scala/spinal/core/internals/ComponentEmitterVhdl.scala
@@ -196,7 +196,8 @@ class ComponentEmitterVhdl(
     })
 
     //Wrap expression which need it
-    cutLongExpressions()
+    if(spinalConfig.cutLongExpressions)
+      cutLongExpressions()
     expressionToWrap --= wrappedExpressionToName.keysIterator
     component.dslBody.walkStatements { s =>
       s.walkExpression { e =>


### PR DESCRIPTION
<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
